### PR TITLE
N/A: update frame rate flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ _____________
 The modifiers are configurable and the application can be further extended to have more features and functionalities. 
 Below is a list of the supported modifiers
 
-#### [Frame Rate Modifier](./processor/modifiers/fps.go)
+#### [Frame Rate Modifier](./processor/modifiers/engine/fps.go)
 
 This modifier changes the limits for the frame rate limiters. Below are the configuration values that change this
 behavior:
@@ -79,19 +79,25 @@ __Target__: `\Engine\Config\BaseEngine.ini`
 |  `MaxClientFrameRate`  |   128   |     Changes the game client's maximum frame rate when the `Smoothed` option is unset     |
 
 
-Below are the configuration flags that modify these values
+Below are the configuration flags that modify these values, alongside their default values applied when you don't use
+or specify that configuration option and value.
 
-|    Flag     | Type  | Default |           Description            |
-|:-----------:|:-----:|:-------:|:--------------------------------:|
-|   `-min`    | `int` |   60    | Minimum frame rate value to set  |
-|   `-max`    | `int` |   60    | Maximum frame rate value to set  |
-| `-smoothed` | `int` |   60    | Smoothed frame rate value to set |
+|  Flag  | Type  | Default |                                  Description                                   |
+|:------:|:-----:|:-------:|:------------------------------------------------------------------------------:|
+| `-cap` | `int` |   300   |       Frame rate limit value to set when the Smoothed option is disabled       |
+| `-min` | `int` |   60    | Minimum frame rate value to set when the Smoothed frame rate option is enabled |
+| `-max` | `int` |   300   | Maximum frame rate value to set when the Smoothed frame rate option is enabled |
 
 
-#### [Input Bindings Modifiers](./processor/modifiers/sprint_lock.go)
+#### [Input Bindings Modifiers](./processor/modifiers/input)
 
-This modifier changes the behavior of the Sprint action, causing it to toggle __off__ when held down, which is the 
-opposite behavior of the key. It allows to always sprint without holding the assigned key for it.
+These modifiers change the behavior of the Sprint and Crouch actions.
+
+[Sprint lock](./processor/modifiers/input/sprint_lock.go) causes it to toggle __off__ when held down, which is the opposite behavior of the key. It allows to always 
+sprint without holding the assigned key for it.
+
+[Crouch lock](./processor/modifiers/input/crouch_lock.go) causes it to behave as a press-and-hold key; instead of an on-off switch. It can be still locked in crouch 
+mode by combining the crouch key and hitting the jump key, for instance, and unlocked by pressing the jump key again.
 
 __Target__: `\APBGame\Config\DefaultInput.ini`
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,9 +13,9 @@ type Config struct {
 }
 
 type FrameRateConfig struct {
-	MaxRate      int
-	MinRate      int
-	SmoothedRate int
+	Cap int
+	Min int
+	Max int
 }
 
 type InputConfig struct {
@@ -24,28 +24,16 @@ type InputConfig struct {
 	Reset      bool
 }
 
-func newInputConfig(lockSprint, holdCrouch, reset bool) *InputConfig {
-	if reset {
-		return &InputConfig{}
-	}
-
-	if !lockSprint && !holdCrouch {
-		return nil
-	}
-
-	return &InputConfig{
-		SprintLock: lockSprint,
-		CrouchHold: holdCrouch,
-	}
-}
-
 func NewConfig() (*Config, error) {
 	path := flag.String("dir", "", "path to the game's installation folder")
 
 	// frame rate options
-	min := flag.Int("min", 60, "min frame rate value to set")
-	max := flag.Int("max", 300, "max frame rate value to set")
-	smoothed := flag.Int("smoothed", 300, "smoothed frame rate value to set")
+	frameRateCap := flag.Int("frameRateCap", 300,
+		"frame rate limit value to set when the Smoothed frame rate option is disabled")
+	frameRateMin := flag.Int("frameRateMin", 60,
+		"minimum frame rate value to set when the Smoothed frame rate option is enabled")
+	frameRateMax := flag.Int("frameRateCap", 300,
+		"maximum frame rate value to set when the Smoothed frame rate option is enabled")
 
 	// input options
 	lockSprint := flag.Bool("lock-sprint", false,
@@ -73,10 +61,25 @@ func NewConfig() (*Config, error) {
 	return &Config{
 		Path: *path,
 		FrameRate: &FrameRateConfig{
-			MinRate:      *min,
-			MaxRate:      *max,
-			SmoothedRate: *smoothed,
+			Min: *frameRateMin,
+			Cap: *frameRateCap,
+			Max: *frameRateMax,
 		},
 		Input: newInputConfig(*lockSprint, *holdCrouch, *resetInput),
 	}, nil
+}
+
+func newInputConfig(lockSprint, holdCrouch, reset bool) *InputConfig {
+	if reset {
+		return &InputConfig{}
+	}
+
+	if !lockSprint && !holdCrouch {
+		return nil
+	}
+
+	return &InputConfig{
+		SprintLock: lockSprint,
+		CrouchHold: holdCrouch,
+	}
 }

--- a/processor/modifiers/engine/fps.go
+++ b/processor/modifiers/engine/fps.go
@@ -9,20 +9,20 @@ import (
 )
 
 const (
-	minRateKey      = "MinSmoothedFrameRate"
-	smoothedRateKey = "MaxSmoothedFrameRate"
-	maxRateKey      = "MaxClientFrameRate"
+	frameRateCapKey = "MaxClientFrameRate"
+	frameRateMinKey = "MinSmoothedFrameRate"
+	frameRateMaxKey = "MaxSmoothedFrameRate"
 
-	defaultMinRate      = 22
-	defaultMaxRate      = 128
-	defaultSmoothedRate = 100
+	defaultFrameRateCap = 128
+	defaultFrameRateMin = 22
+	defaultFrameRateMax = 100
 
 	fpsModifierPath   = `/Engine/Config/BaseEngine.ini`
 	fpsModifierFormat = "%s=%d"
 )
 
-// FrameRate creates a new frame-rate Modifier, which will change the min, max and smoothed frame rate
-// configuration values
+// FrameRate creates a new frame-rate Modifier, which affects the engine's configuration for frame rate;
+// updating its smoothed minimum and maximum frame rates, as well as the frame rate cap.
 func FrameRate(cfg config.FrameRateConfig) modifiers.Modifier {
 	sb := &strings.Builder{}
 	sb.WriteString(fpsModifierFormat)
@@ -34,26 +34,26 @@ func FrameRate(cfg config.FrameRateConfig) modifiers.Modifier {
 
 	mods := make([]modifiers.Attribute, 0, 3)
 
-	if cfg.MinRate > 0 && cfg.MinRate != defaultMinRate {
+	if cfg.Cap > 0 && cfg.Cap != defaultFrameRateCap {
 		mods = append(mods, modifiers.KeyValue[int]{
-			Key:    minRateKey,
-			Data:   cfg.MinRate,
+			Key:    frameRateCapKey,
+			Data:   cfg.Cap,
 			Format: sb.String(),
 		})
 	}
 
-	if cfg.MaxRate > 0 && cfg.MaxRate != defaultMaxRate {
+	if cfg.Min > 0 && cfg.Min != defaultFrameRateMin {
 		mods = append(mods, modifiers.KeyValue[int]{
-			Key:    maxRateKey,
-			Data:   cfg.MaxRate,
+			Key:    frameRateMinKey,
+			Data:   cfg.Min,
 			Format: sb.String(),
 		})
 	}
 
-	if cfg.SmoothedRate > 0 && cfg.SmoothedRate != defaultSmoothedRate {
+	if cfg.Max > 0 && cfg.Max != defaultFrameRateMax {
 		mods = append(mods, modifiers.KeyValue[int]{
-			Key:    smoothedRateKey,
-			Data:   cfg.SmoothedRate,
+			Key:    frameRateMaxKey,
+			Data:   cfg.Max,
 			Format: sb.String(),
 		})
 	}

--- a/processor/modifiers/engine/fps_test.go
+++ b/processor/modifiers/engine/fps_test.go
@@ -17,33 +17,33 @@ func TestNewFPSModifier(t *testing.T) {
 	}
 
 	for _, testcase := range []struct {
-		name     string
-		min      int
-		max      int
-		smoothed int
+		name         string
+		frameRateCap int
+		frameRateMin int
+		frameRateMax int
 
 		wants modifiers.Modifier
 	}{
 		{
-			name:     "Success/Simple",
-			min:      60,
-			max:      300,
-			smoothed: 300,
+			name:         "Success/Simple",
+			frameRateCap: 300,
+			frameRateMin: 60,
+			frameRateMax: 300,
 			wants: modifiers.Modifier{
 				FilePath: fpsModifierPath,
 				Attributes: []modifiers.Attribute{
 					modifiers.KeyValue[int]{
-						Key:    minRateKey,
-						Data:   60,
-						Format: fpsModifierFormat + lf,
-					},
-					modifiers.KeyValue[int]{
-						Key:    maxRateKey,
+						Key:    frameRateCapKey,
 						Data:   300,
 						Format: fpsModifierFormat + lf,
 					},
 					modifiers.KeyValue[int]{
-						Key:    smoothedRateKey,
+						Key:    frameRateMinKey,
+						Data:   60,
+						Format: fpsModifierFormat + lf,
+					},
+					modifiers.KeyValue[int]{
+						Key:    frameRateMaxKey,
 						Data:   300,
 						Format: fpsModifierFormat + lf,
 					},
@@ -51,13 +51,13 @@ func TestNewFPSModifier(t *testing.T) {
 			},
 		},
 		{
-			name: "Success/OnlyMax",
-			max:  300,
+			name:         "Success/OnlyCap",
+			frameRateCap: 300,
 			wants: modifiers.Modifier{
 				FilePath: fpsModifierPath,
 				Attributes: []modifiers.Attribute{
 					modifiers.KeyValue[int]{
-						Key:    maxRateKey,
+						Key:    frameRateCapKey,
 						Data:   300,
 						Format: fpsModifierFormat + lf,
 					},
@@ -74,9 +74,9 @@ func TestNewFPSModifier(t *testing.T) {
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			mod := FrameRate(config.FrameRateConfig{
-				MinRate:      testcase.min,
-				MaxRate:      testcase.max,
-				SmoothedRate: testcase.smoothed,
+				Cap: testcase.frameRateCap,
+				Min: testcase.frameRateMin,
+				Max: testcase.frameRateMax,
 			})
 			require.Equal(t, testcase.wants, mod)
 		})

--- a/processor/modifiers/key_value_test.go
+++ b/processor/modifiers/key_value_test.go
@@ -66,9 +66,9 @@ func TestKeyValueModifier_Apply(t *testing.T) {
 			targetDir:     "/Engine/Config",
 			targetFile:    "/BaseEngine.ini",
 			modifier: engine.FrameRate(config.FrameRateConfig{
-				MinRate:      60,
-				MaxRate:      300,
-				SmoothedRate: 300,
+				Cap: 300,
+				Min: 60,
+				Max: 300,
 			}),
 		},
 		{
@@ -77,9 +77,9 @@ func TestKeyValueModifier_Apply(t *testing.T) {
 			targetDir:     "/Engine/Config",
 			targetFile:    "/BaseEngine.ini",
 			modifier: engine.FrameRate(config.FrameRateConfig{
-				MinRate:      60,
-				MaxRate:      300,
-				SmoothedRate: 300,
+				Cap: 300,
+				Min: 60,
+				Max: 300,
 			}),
 		},
 		{

--- a/processor/modifiers/modifier_with_logs.go
+++ b/processor/modifiers/modifier_with_logs.go
@@ -31,7 +31,7 @@ type modifierWithLogs struct {
 }
 
 func (m modifierWithLogs) Apply(ctx context.Context, basePath string) error {
-	path := m.m.FilePath + basePath
+	path := basePath + m.m.FilePath
 
 	m.logger.InfoContext(ctx,
 		"applying modifiers to config file",

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -86,9 +86,9 @@ func TestProcessor_Run(t *testing.T) {
 			cfg: &config.Config{
 				Path: baseDir + "fps/complete_orig" + topLevel + binariesDir,
 				FrameRate: &config.FrameRateConfig{
-					MinRate:      60,
-					MaxRate:      300,
-					SmoothedRate: 300,
+					Cap: 300,
+					Min: 60,
+					Max: 300,
 				},
 			},
 		},
@@ -100,9 +100,9 @@ func TestProcessor_Run(t *testing.T) {
 			cfg: &config.Config{
 				Path: baseDir + "fps/short_orig" + topLevel + binariesDir,
 				FrameRate: &config.FrameRateConfig{
-					MinRate:      60,
-					MaxRate:      300,
-					SmoothedRate: 300,
+					Cap: 300,
+					Min: 60,
+					Max: 300,
 				},
 			},
 		},
@@ -114,9 +114,9 @@ func TestProcessor_Run(t *testing.T) {
 			cfg: &config.Config{
 				Path: baseDir + "fps/short_fake",
 				FrameRate: &config.FrameRateConfig{
-					MinRate:      60,
-					MaxRate:      300,
-					SmoothedRate: 300,
+					Cap: 300,
+					Min: 60,
+					Max: 300,
 				},
 			},
 			err: processor.ErrInvalidPath,


### PR DESCRIPTION
This PR updates the frame-rate flags to something more meaningful, with the proposed changes below. It also updates the references in the code to these values, providing a clearer understanding of their usage.


Before | After
:----:|:----:
`-min` | `-min`
`-max` | `-cap`
`-smoothed` | `-max`

The reason for the (breaking) change in the CLI flags for frame rate is that it is in fact more reasonable to refer to min/max as it is, since they only refer to the Smoothed minimums and maximums. As for when Smoothed is disabled, neither of those values apply and only the limit. To keep it concise I went with `cap`, for the frame rate limit when Smoothed is off.