### PR TITLE
fix(flags): fix CLI flag identifiers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,11 +28,11 @@ func NewConfig() (*Config, error) {
 	path := flag.String("dir", "", "path to the game's installation folder")
 
 	// frame rate options
-	frameRateCap := flag.Int("frameRateCap", 0,
+	frameRateCap := flag.Int("cap", 0,
 		"frame rate limit value to set when the Smoothed frame rate option is disabled")
-	frameRateMin := flag.Int("frameRateMin", 22,
+	frameRateMin := flag.Int("min", 22,
 		"minimum frame rate value to set when the Smoothed frame rate option is enabled")
-	frameRateMax := flag.Int("frameRateCap", 128,
+	frameRateMax := flag.Int("max", 128,
 		"maximum frame rate value to set when the Smoothed frame rate option is enabled")
 
 	// input options


### PR DESCRIPTION
With the latest changes, some of the flags' identifiers were changed accidentally. This PR reverts those changes to comply with the README's description on FPS modifiers.