### PR TITLE
fix(config) Fix default path in config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,15 @@ func readConfigFile(buf []byte) (*Config, error) {
 		return nil, err
 	}
 
+	if config.Path == "" {
+		currentPath, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+
+		config.Path = currentPath
+	}
+
 	return config, nil
 }
 


### PR DESCRIPTION
This change adds the default path on the config data structure when it is unset